### PR TITLE
Get categories by id service tests - little refactoring

### DIFF
--- a/src/Tests/Nop.Plugin.Api.Tests/Nop.Plugin.Api.Tests.csproj
+++ b/src/Tests/Nop.Plugin.Api.Tests/Nop.Plugin.Api.Tests.csproj
@@ -124,7 +124,7 @@
     <Compile Include="ServicesTests\Categories\GetCategories\CategoriesApiServiceTests_GetCategories_SinceIdParameter.cs" />
     <Compile Include="ServicesTests\Categories\GetCategories\CategoryApiServiceTests_GetCategories_DefaultParameters.cs" />
     <Compile Include="ServicesTests\Categories\GetCategoriesCount\CategoryApiServiceTests_GetCategoriesCount_DefaultParameters.cs" />
-    <Compile Include="ServicesTests\Categories\CategoryApiServiceTests_GetCategoryById.cs" />
+    <Compile Include="ServicesTests\Categories\GetCategoryById\CategoryApiServiceTests_GetCategoryById.cs" />
     <Compile Include="SerializersTests\DummyObjects\DummySerializableObject.cs" />
     <Compile Include="SerializersTests\JsonFieldsSerializerTests_Serialize.cs" />
     <Compile Include="ServicesTests\Categories\GetCategories\CategoryApiServiceTests_GetCategories_CreatedParameters.cs" />

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Categories/GetCategoryById/CategoryApiServiceTests_GetCategoryById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Categories/GetCategoryById/CategoryApiServiceTests_GetCategoryById.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Nop.Core.Data;
+﻿using Nop.Core.Data;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Services;
 using NUnit.Framework;
 using Rhino.Mocks;
 
-namespace Nop.Plugin.Api.Tests.ServicesTests.Categories
+namespace Nop.Plugin.Api.Tests.ServicesTests.Categories.GetCategoryById
 {
     [TestFixture]
     public class CategoryApiServiceTests_GetCategoryById
@@ -34,6 +29,23 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Categories
         }
 
         [Test]
+        [TestCase(-2)]
+        [TestCase(0)]
+        public void WhenNegativeOrZeroCategoryIdPassed_ShouldReturnNull(int negativeOrZeroCategoryId)
+        {
+            // Aranges
+            var categoryRepoMock = MockRepository.GenerateMock<IRepository<Category>>();
+            var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
+
+            // Act
+            var cut = new CategoryApiService(categoryRepoMock, productCategoryRepo);
+            var result = cut.GetCategoryById(negativeOrZeroCategoryId);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [Test]
         public void WhenCategoryIsReturnedByTheRepository_ShouldReturnTheSameCategory()
         {
             int categoryId = 3;
@@ -51,23 +63,6 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Categories
 
             // Assert
             Assert.AreSame(category, result);
-        }
-
-        [Test]
-        [TestCase(-2)]
-        [TestCase(0)]
-        public void WhenNegativeOrZeroCategoryIdPassed_ShouldReturnNull(int negativeOrZeroCategoryId)
-        {
-            // Arange
-            var categoryRepoMock = MockRepository.GenerateMock<IRepository<Category>>();
-            var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
-
-            // Act
-            var cut = new CategoryApiService(categoryRepoMock, productCategoryRepo);
-            var result = cut.GetCategoryById(negativeOrZeroCategoryId);
-
-            // Assert
-            Assert.IsNull(result);
         }
     }
 }


### PR DESCRIPTION
- Just moved the CategoryApiServiceTests_GetCategoryById.cs to GetCategoryById folder to be consistent with the tests structure.