### PR TITLE
Product category mappings get mappings by id service tests

### DIFF
--- a/src/Plugins/Nop.Plugin.Api/Services/ProductCategoryMappingsApiService.cs
+++ b/src/Plugins/Nop.Plugin.Api/Services/ProductCategoryMappingsApiService.cs
@@ -32,7 +32,10 @@ namespace Nop.Plugin.Api.Services
 
         public ProductCategory GetById(int id)
         {
-            return _productCategoryMappingsRepository.Table.FirstOrDefault(mapping => mapping.Id == id);
+            if (id <= 0)
+                return null;
+
+            return _productCategoryMappingsRepository.GetById(id);
         }
 
         private IQueryable<ProductCategory> GetMappingsQuery(int productId = Configurations.DefaultProductId, 

--- a/src/Tests/Nop.Plugin.Api.Tests/ConvertersTests/ObjectConverter/ObjectConverterTests_ToObject.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ConvertersTests/ObjectConverter/ObjectConverterTests_ToObject.cs
@@ -167,7 +167,7 @@ namespace Nop.Plugin.Api.Tests.ConvertersTests.ObjectConverter
         public void WhenCollectionContainsValidStringProperty_ShouldSetTheObjectStringPropertyValueToTheCollectionStringPropertyValue(string stringPropertyName)
         {
             //Arange
-            IApiTypeConverter apiTypeConverterStub = MockRepository.GenerateMock<IApiTypeConverter>();
+            IApiTypeConverter apiTypeConverterStub = MockRepository.GenerateStub<IApiTypeConverter>();
 
             IObjectConverter objectConverter = new Converters.ObjectConverter(apiTypeConverterStub);
 
@@ -188,7 +188,7 @@ namespace Nop.Plugin.Api.Tests.ConvertersTests.ObjectConverter
         public void WhenCollectionContainsInvalidStringProperty_ShouldReturnTheObjectWithItsStringPropertySetToTheDefaultValue(string invalidStringPropertyName)
         {
             //Arange
-            IApiTypeConverter apiTypeConverterStub = MockRepository.GenerateMock<IApiTypeConverter>();
+            IApiTypeConverter apiTypeConverterStub = MockRepository.GenerateStub<IApiTypeConverter>();
 
             IObjectConverter objectConverter = new Converters.ObjectConverter(apiTypeConverterStub);
 

--- a/src/Tests/Nop.Plugin.Api.Tests/Nop.Plugin.Api.Tests.csproj
+++ b/src/Tests/Nop.Plugin.Api.Tests/Nop.Plugin.Api.Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ServicesTests\Orders\GetOrdersCount\OrderApiServiceTests_GetOrdersCount_CreatedParameters.cs" />
     <Compile Include="ServicesTests\Orders\GetOrdersCount\OrderApiServiceTests_GetOrdersCount_DefaultParameters.cs" />
     <Compile Include="ServicesTests\Orders\GetOrdersCount\OrderApiServiceTests_GetOrdersCount_CustomerIdParameter.cs" />
+    <Compile Include="ServicesTests\ProductCategoryMappings\GetMappingById\ProductCategoryMappingsApiServiceTests_GetOrderById.cs" />
     <Compile Include="ServicesTests\Products\GetProductsCount\ProductApiServiceTests_GetProductsCount_VendorNameParameter.cs" />
     <Compile Include="ServicesTests\Products\GetProductById\ProductApiServiceTests_GetProductById.cs" />
     <Compile Include="ServicesTests\Products\GetProductsCount\ProductApiServiceTests_GetProductsCount_CategoryIdParameter.cs" />

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Categories/GetCategoryById/CategoryApiServiceTests_GetCategoryById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Categories/GetCategoryById/CategoryApiServiceTests_GetCategoryById.cs
@@ -34,11 +34,11 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Categories.GetCategoryById
         public void WhenNegativeOrZeroCategoryIdPassed_ShouldReturnNull(int negativeOrZeroCategoryId)
         {
             // Aranges
-            var categoryRepoMock = MockRepository.GenerateMock<IRepository<Category>>();
+            var categoryRepoStub = MockRepository.GenerateStub<IRepository<Category>>();
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
 
             // Act
-            var cut = new CategoryApiService(categoryRepoMock, productCategoryRepo);
+            var cut = new CategoryApiService(categoryRepoStub, productCategoryRepo);
             var result = cut.GetCategoryById(negativeOrZeroCategoryId);
 
             // Assert

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Orders/GetOrderById/OrderApiServiceTests_GetOrderById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Orders/GetOrderById/OrderApiServiceTests_GetOrderById.cs
@@ -32,10 +32,10 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Orders.GetOrderById
         public void WhenNegativeOrZeroOrderIdPassed_ShouldReturnNull(int negativeOrZeroOrderId)
         {
             // Aranges
-            var orderRepoMock = MockRepository.GenerateMock<IRepository<Order>>();
+            var orderRepoStub = MockRepository.GenerateStub<IRepository<Order>>();
 
             // Act
-            var cut = new OrderApiService(orderRepoMock);
+            var cut = new OrderApiService(orderRepoStub);
             var result = cut.GetOrderById(negativeOrZeroOrderId);
 
             // Assert

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/ProductCategoryMappings/GetMappingById/ProductCategoryMappingsApiServiceTests_GetOrderById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/ProductCategoryMappings/GetMappingById/ProductCategoryMappingsApiServiceTests_GetOrderById.cs
@@ -1,0 +1,63 @@
+﻿using Nop.Core.Data;
+using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.Services;
+using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace Nop.Plugin.Api.Tests.ServicesTests.ProductCategoryMappings.GetMappingById
+{
+    [TestFixture]
+    public class ProductCategoryMappingsApiServiceTests_GetOrderById
+    {
+        [Test]
+        public void WhenNullIsReturnedByTheRepository_ShouldReturnNull()
+        {
+            int mappingId = 3;
+            
+            // Arange
+            var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
+            productCategoryRepo.Stub(x => x.GetById(mappingId)).Return(null);
+            
+            // Act  
+            var cut = new ProductCategoryMappingsApiService(productCategoryRepo);
+            var result = cut.GetById(mappingId);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        [TestCase(-2)]
+        [TestCase(0)]
+        public void WhenNegativeOrZeroMappingIdPassed_ShouldReturnNull(int negativeOrZeroOrderId)
+        {
+            // Aranges
+            var mappingRepoMock = MockRepository.GenerateStub<IRepository<ProductCategory>>();
+
+            // Act
+            var cut = new ProductCategoryMappingsApiService(mappingRepoMock);
+            var result = cut.GetById(negativeOrZeroOrderId);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void WhenMappingIsReturnedByTheRepository_ShouldReturnTheSameMapping()
+        {
+            int mappingId = 3;
+            var mapping = new ProductCategory() { Id = 3 };
+
+            // Arange
+            var mappingRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
+            mappingRepo.Stub(x => x.GetById(mappingId)).Return(mapping);
+            
+            // Act
+            var cut = new ProductCategoryMappingsApiService(mappingRepo);
+            var result = cut.GetById(mappingId);
+
+            // Assert
+            Assert.AreSame(mapping, result);
+        }
+    }
+}

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Products/GetProductById/ProductApiServiceTests_GetProductById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Products/GetProductById/ProductApiServiceTests_GetProductById.cs
@@ -36,12 +36,12 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Products.GetProductById
         public void WhenNegativeOrZeroProductIdPassed_ShouldReturnNull(int negativeOrZeroProductId)
         {
             // Aranges
-            var productRepoMock = MockRepository.GenerateMock<IRepository<Product>>();
+            var productRepoStub = MockRepository.GenerateStub<IRepository<Product>>();
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
             var vendorRepo = MockRepository.GenerateStub<IRepository<Vendor>>();
 
             // Act
-            var cut = new ProductApiService(productRepoMock, productCategoryRepo, vendorRepo);
+            var cut = new ProductApiService(productRepoStub, productCategoryRepo, vendorRepo);
             var result = cut.GetProductById(negativeOrZeroProductId);
 
             // Assert


### PR DESCRIPTION
- Added tests for the GetById method from the ProductCategoryMappingApiService
- Replace mocks with stubs in some tests where the mock was used incorrectly