### PR TITLE
Update the tests

### DIFF
--- a/src/Plugins/Nop.Plugin.Api/Controllers/OrderItemsController.cs
+++ b/src/Plugins/Nop.Plugin.Api/Controllers/OrderItemsController.cs
@@ -11,7 +11,6 @@ using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.Constants;
 using Nop.Plugin.Api.Delta;
 using Nop.Plugin.Api.DTOs.OrderItems;
-using Nop.Plugin.Api.DTOs.Orders;
 using Nop.Plugin.Api.JSON.ActionResults;
 using Nop.Plugin.Api.MappingExtensions;
 using Nop.Plugin.Api.ModelBinders;

--- a/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Categories/CategoriesControllerTests_GetCategories.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Categories/CategoriesControllerTests_GetCategories.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Net;
+using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Results;
 using AutoMock;
@@ -34,11 +36,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Categories
             //Arange
             var autoMocker = new RhinoAutoMocker<CategoriesApiController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<CategoriesRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                           .IgnoreArguments()
+                                                           .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetCategories(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+                
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -54,11 +62,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Categories
             //Arange
             var autoMocker = new RhinoAutoMocker<CategoriesApiController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<CategoriesRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                           .IgnoreArguments()
+                                                           .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetCategories(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]

--- a/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Customers/CustomersControllerTests_GetCustomers.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Customers/CustomersControllerTests_GetCustomers.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Results;
 using AutoMock;
@@ -121,11 +123,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Customers
             //Arange
             var autoMocker = new RhinoAutoMocker<CustomersController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<CustomersRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                                        .IgnoreArguments()
+                                                                        .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetCustomers(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -141,11 +149,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Customers
             //Arange
             var autoMocker = new RhinoAutoMocker<CustomersController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<CustomersRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                                        .IgnoreArguments()
+                                                                        .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetCustomers(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
     }
 }

--- a/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Customers/CustomersControllerTests_Search.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Customers/CustomersControllerTests_Search.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Net;
+using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Results;
 using AutoMock;
@@ -123,11 +125,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Customers
             //Arange
             var autoMocker = new RhinoAutoMocker<CustomersController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<CustomersRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                                        .IgnoreArguments()
+                                                                        .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.Search(parametersModel);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -143,11 +151,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Customers
             //Arange
             var autoMocker = new RhinoAutoMocker<CustomersController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<CustomersRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                                        .IgnoreArguments()
+                                                                        .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.Search(parametersModel);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
     }
 }

--- a/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Orders/OrdersControllerTests_GetOrders.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/Orders/OrdersControllerTests_GetOrders.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Threading;
 using System.Web.Http;
-using System.Web.Http.Results;
 using AutoMock;
 using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.Constants;
@@ -129,11 +130,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Orders
             //Arange
             var autoMocker = new RhinoAutoMocker<OrdersController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<OrdersRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                    .IgnoreArguments()
+                                                    .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetOrders(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -149,11 +156,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.Orders
             //Arange
             var autoMocker = new RhinoAutoMocker<OrdersController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<OrdersRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                    .IgnoreArguments()
+                                                    .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetOrders(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
     }
 }

--- a/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/ProductCategoryMappings/ProductCategoryMappingsControllerTests_GetMappings.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/ProductCategoryMappings/ProductCategoryMappingsControllerTests_GetMappings.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Net;
+using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Results;
 using AutoMock;
@@ -57,11 +59,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.ProductCategoryMappings
             //Arange
             var autoMocker = new RhinoAutoMocker<ProductCategoryMappingsController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<ProductCategoryMappingsRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                 .IgnoreArguments()
+                                                 .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetMappings(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -77,11 +85,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.ProductCategoryMappings
             //Arange
             var autoMocker = new RhinoAutoMocker<ProductCategoryMappingsController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<ProductCategoryMappingsRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                .IgnoreArguments()
+                                                .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetMappings(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]

--- a/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/ShoppingCartItems/ShoppingCartItemsControllerTests_GetShoppingCartItems.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ControllersTests/ShoppingCartItems/ShoppingCartItemsControllerTests_GetShoppingCartItems.cs
@@ -1,4 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Threading;
 using System.Web.Http;
 using System.Web.Http.Results;
 using AutoMock;
@@ -6,10 +9,10 @@ using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.Constants;
 using Nop.Plugin.Api.Controllers;
 using Nop.Plugin.Api.DTOs.ShoppingCarts;
-using Nop.Plugin.Api.Maps;
 using Nop.Plugin.Api.Models.ShoppingCartsParameters;
 using Nop.Plugin.Api.Serializers;
 using Nop.Plugin.Api.Services;
+using Nop.Plugin.Api.Tests.ModelBinderTests.DummyObjects;
 using NUnit.Framework;
 using Rhino.Mocks;
 
@@ -30,12 +33,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.ShoppingCartItems
 
             //Arange
             var autoMocker = new RhinoAutoMocker<ShoppingCartItemsController>();
-           
+
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<ShoppingCartItemsRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                        .IgnoreArguments()
+                                                        .Return(string.Empty);
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetShoppingCartItems(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -51,11 +59,17 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.ShoppingCartItems
             //Arange
             var autoMocker = new RhinoAutoMocker<ShoppingCartItemsController>();
 
+            autoMocker.Get<IJsonFieldsSerializer>().Stub(x => x.Serialize(Arg<ShoppingCartItemsRootObject>.Is.Anything, Arg<string>.Is.Anything))
+                                                        .IgnoreArguments()
+                                                        .Return(string.Empty);
+
             //Act
             IHttpActionResult result = autoMocker.ClassUnderTest.GetShoppingCartItems(parameters);
 
             //Assert
-            Assert.IsInstanceOf<BadRequestErrorMessageResult>(result);
+            var statusCode = result.ExecuteAsync(new CancellationToken()).Result.StatusCode;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, statusCode);
         }
 
         [Test]
@@ -66,7 +80,7 @@ namespace Nop.Plugin.Api.Tests.ControllersTests.ShoppingCartItems
             //Arange
             var autoMocker = new RhinoAutoMocker<ShoppingCartItemsController>();
 
-            autoMocker.Get<IShoppingCartItemApiService>().Expect(x => x.GetShoppingCartItems(0, parameters.CreatedAtMin,
+            autoMocker.Get<IShoppingCartItemApiService>().Expect(x => x.GetShoppingCartItems(null, parameters.CreatedAtMin,
                                                                                parameters.CreatedAtMax, parameters.UpdatedAtMin,
                                                                                parameters.UpdatedAtMax, parameters.Limit,
                                                                                parameters.Page)).Return(new List<ShoppingCartItem>());

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Categories/GetCategoryById/CategoryApiServiceTests_GetCategoryById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Categories/GetCategoryById/CategoryApiServiceTests_GetCategoryById.cs
@@ -1,4 +1,6 @@
-﻿using Nop.Core.Data;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Nop.Core.Data;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Services;
 using NUnit.Framework;
@@ -16,6 +18,7 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Categories.GetCategoryById
             
             // Arange
             var categoryRepo = MockRepository.GenerateStub<IRepository<Category>>();
+            categoryRepo.Stub(x => x.Table).Return((new List<Category>()).AsQueryable());
             categoryRepo.Stub(x => x.GetById(categoryId)).Return(null);
 
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
@@ -53,6 +56,12 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Categories.GetCategoryById
 
             // Arange
             var categoryRepo = MockRepository.GenerateStub<IRepository<Category>>();
+
+            var list = new List<Category>();
+            list.Add(category);
+
+            categoryRepo.Stub(x => x.Table).Return(list.AsQueryable());
+
             categoryRepo.Stub(x => x.GetById(categoryId)).Return(category);
 
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Orders/GetOrderById/OrderApiServiceTests_GetOrderById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Orders/GetOrderById/OrderApiServiceTests_GetOrderById.cs
@@ -1,4 +1,6 @@
-﻿using Nop.Core.Data;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Nop.Core.Data;
 using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.Services;
 using NUnit.Framework;
@@ -16,8 +18,9 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Orders.GetOrderById
             
             // Arange
             var orderRepo = MockRepository.GenerateStub<IRepository<Order>>();
+            orderRepo.Stub(x => x.Table).Return((new List<Order>()).AsQueryable());
             orderRepo.Stub(x => x.GetById(orderId)).Return(null);
-            
+
             // Act  
             var cut = new OrderApiService(orderRepo);
             var result = cut.GetOrderById(orderId);
@@ -50,6 +53,11 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Orders.GetOrderById
 
             // Arange
             var orderRepo = MockRepository.GenerateStub<IRepository<Order>>();
+
+            var list = new List<Order>();
+            list.Add(order);
+
+            orderRepo.Stub(x => x.Table).Return(list.AsQueryable());
             orderRepo.Stub(x => x.GetById(orderId)).Return(order);
             
             // Act

--- a/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Products/GetProductById/ProductApiServiceTests_GetProductById.cs
+++ b/src/Tests/Nop.Plugin.Api.Tests/ServicesTests/Products/GetProductById/ProductApiServiceTests_GetProductById.cs
@@ -1,4 +1,6 @@
-﻿using Nop.Core.Data;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Nop.Core.Data;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Vendors;
 using Nop.Plugin.Api.Services;
@@ -18,6 +20,7 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Products.GetProductById
             // Arange
             var productRepo = MockRepository.GenerateStub<IRepository<Product>>();
             productRepo.Stub(x => x.GetById(productId)).Return(null);
+            productRepo.Stub(x => x.Table).Return((new List<Product>()).AsQueryable());
 
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
             var vendorRepo = MockRepository.GenerateStub<IRepository<Vendor>>();
@@ -37,6 +40,8 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Products.GetProductById
         {
             // Aranges
             var productRepoStub = MockRepository.GenerateStub<IRepository<Product>>();
+            productRepoStub.Stub(x => x.Table).Return((new List<Product>()).AsQueryable());
+
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
             var vendorRepo = MockRepository.GenerateStub<IRepository<Vendor>>();
 
@@ -57,6 +62,11 @@ namespace Nop.Plugin.Api.Tests.ServicesTests.Products.GetProductById
             // Arange
             var productRepo = MockRepository.GenerateStub<IRepository<Product>>();
             productRepo.Stub(x => x.GetById(productId)).Return(product);
+
+            var list = new List<Product>();
+            list.Add(product);
+
+            productRepo.Stub(x => x.Table).Return(list.AsQueryable());
 
             var productCategoryRepo = MockRepository.GenerateStub<IRepository<ProductCategory>>();
             var vendorRepo = MockRepository.GenerateStub<IRepository<Vendor>>();


### PR DESCRIPTION
- Update the tests with the latest changes in the namespaces and the error handling.
- Changed the way the concrete classes are resolved in the controllers, i.e. the OrderSettings is a concrete type which is now resolved using property injection. This is needed because the auto mocking that we are using in the tests does not support concrete type dependencies. It supports only interfaces.